### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,4 +1,6 @@
 name: Shell Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/JoannaaKL/dotfiles/security/code-scanning/1](https://github.com/JoannaaKL/dotfiles/security/code-scanning/1)

To fix this issue, explicitly set the workflow or job-level permissions to their minimum necessary values, preventing GitHub from granting excessive repository access to the workflow’s GITHUB_TOKEN. Since this workflow only checks out code and runs shell commands, all it needs is `contents: read`. Add a `permissions:` block near the top of the YAML file, immediately following the `name:` line and before `on:`, or at the job level if only one job exists. The root-level declaration applies to all jobs unless overridden. No code changes within the steps are required. 

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
